### PR TITLE
Fix mobile landscape click events and set chart to 50% width

### DIFF
--- a/apps/stonksville/src/app/page.tsx
+++ b/apps/stonksville/src/app/page.tsx
@@ -2,6 +2,9 @@ import { TradingChart } from "@/components/trading-chart";
 
 const Page = () => {
   return (
+    // h-full not h-dvh: on rotated mobile, body height is 100dvw via CSS media query,
+    // and 100dvh would resolve to the portrait height causing overflow. Parent chain:
+    // html/body { height: 100% } in globals.css, body { height: 100dvw } when rotated.
     <main className="h-full w-full overflow-hidden">
       <TradingChart />
     </main>

--- a/apps/stonksville/src/app/page.tsx
+++ b/apps/stonksville/src/app/page.tsx
@@ -2,7 +2,7 @@ import { TradingChart } from "@/components/trading-chart";
 
 const Page = () => {
   return (
-    <main className="h-dvh w-full overflow-hidden">
+    <main className="h-full w-full overflow-hidden">
       <TradingChart />
     </main>
   );

--- a/apps/stonksville/src/app/page.tsx
+++ b/apps/stonksville/src/app/page.tsx
@@ -1,11 +1,10 @@
+import { LandscapeLock } from "@/components/landscape-lock";
 import { TradingChart } from "@/components/trading-chart";
 
 const Page = () => {
   return (
-    // h-full not h-dvh: on rotated mobile, body height is 100dvw via CSS media query,
-    // and 100dvh would resolve to the portrait height causing overflow. Parent chain:
-    // html/body { height: 100% } in globals.css, body { height: 100dvw } when rotated.
-    <main className="h-full w-full overflow-hidden">
+    <main className="h-dvh w-full overflow-hidden">
+      <LandscapeLock />
       <TradingChart />
     </main>
   );

--- a/apps/stonksville/src/app/page.tsx
+++ b/apps/stonksville/src/app/page.tsx
@@ -1,11 +1,12 @@
-import { LandscapeLock } from "@/components/landscape-lock";
+import { LandscapeShell } from "@/components/landscape-lock";
 import { TradingChart } from "@/components/trading-chart";
 
 const Page = () => {
   return (
     <main className="h-dvh w-full overflow-hidden">
-      <LandscapeLock />
-      <TradingChart />
+      <LandscapeShell>
+        <TradingChart />
+      </LandscapeShell>
     </main>
   );
 };

--- a/apps/stonksville/src/app/styles/globals.css
+++ b/apps/stonksville/src/app/styles/globals.css
@@ -25,17 +25,3 @@
     height: 100%;
   }
 }
-
-/* Force landscape orientation on mobile portrait screens */
-@media (max-width: 768px) and (orientation: portrait) {
-  body {
-    width: 100dvh;
-    height: 100dvw;
-    overflow: hidden;
-    transform: rotate(90deg);
-    transform-origin: top left;
-    position: absolute;
-    top: 0;
-    left: 100dvw;
-  }
-}

--- a/apps/stonksville/src/app/styles/globals.css
+++ b/apps/stonksville/src/app/styles/globals.css
@@ -25,3 +25,19 @@
     height: 100%;
   }
 }
+
+/* Force landscape layout on mobile portrait screens.
+   Applied to a wrapper div (not body) so that position:fixed,
+   confetti, and third-party overlays remain in normal viewport space. */
+@media (max-width: 768px) and (orientation: portrait) {
+  .landscape-shell {
+    width: 100dvh;
+    height: 100dvw;
+    overflow: hidden;
+    transform: rotate(90deg);
+    transform-origin: top left;
+    position: absolute;
+    top: 0;
+    left: 100dvw;
+  }
+}

--- a/apps/stonksville/src/components/landscape-lock.tsx
+++ b/apps/stonksville/src/components/landscape-lock.tsx
@@ -1,69 +1,8 @@
-"use client";
-
-import { useEffect, useState } from "react";
-
 /**
- * Requests landscape orientation via the Screen Orientation API on mobile.
- * Falls back to showing a "rotate your device" prompt when the API isn't
- * available and the user is in portrait.
+ * Wrapper that forces landscape layout on mobile portrait screens via CSS rotation.
+ * The rotation is on this div (not body), so position:fixed, confetti, and
+ * third-party DOM insertions remain in normal viewport space.
  */
-export function LandscapeLock() {
-  const [showPrompt, setShowPrompt] = useState(false);
-
-  useEffect(() => {
-    const mq = window.matchMedia("(max-width: 768px)");
-    if (!mq.matches) return;
-
-    // Try the standard Screen Orientation API.
-    // lock() isn't in all TS lib types yet, so we cast through unknown.
-    const orientation = screen.orientation as ScreenOrientation & {
-      lock?: (type: string) => Promise<void>;
-    };
-    if (orientation?.lock) {
-      orientation.lock("landscape").catch(() => {
-        // lock() rejected — browser doesn't support it or we're not fullscreen.
-        // Fall back to the portrait prompt.
-        checkOrientation();
-      });
-    } else {
-      checkOrientation();
-    }
-
-    function checkOrientation() {
-      const isPortrait = window.matchMedia(
-        "(orientation: portrait)",
-      ).matches;
-      setShowPrompt(isPortrait);
-    }
-
-    // Update prompt when orientation changes (e.g. user rotates phone)
-    const orientationMq = window.matchMedia("(orientation: portrait)");
-    const handler = (e: MediaQueryListEvent) => setShowPrompt(e.matches);
-    orientationMq.addEventListener("change", handler);
-
-    return () => {
-      orientationMq.removeEventListener("change", handler);
-      if (orientation?.unlock) {
-        try {
-          orientation.unlock();
-        } catch {
-          // ignore
-        }
-      }
-    };
-  }, []);
-
-  if (!showPrompt) return null;
-
-  return (
-    <div className="fixed inset-0 z-[99999] flex items-center justify-center bg-black/90">
-      <div className="text-center text-white">
-        <div className="mb-4 text-5xl">📱</div>
-        <p className="text-lg font-bold">Rotate your device</p>
-        <p className="mt-1 text-sm text-white/60">
-          This game is best played in landscape
-        </p>
-      </div>
-    </div>
-  );
+export function LandscapeShell({ children }: { children: React.ReactNode }) {
+  return <div className="landscape-shell h-full w-full">{children}</div>;
 }

--- a/apps/stonksville/src/components/landscape-lock.tsx
+++ b/apps/stonksville/src/components/landscape-lock.tsx
@@ -1,8 +1,4 @@
-/**
- * Wrapper that forces landscape layout on mobile portrait screens via CSS rotation.
- * The rotation is on this div (not body), so position:fixed, confetti, and
- * third-party DOM insertions remain in normal viewport space.
- */
+/** Wrapper for the .landscape-shell class defined in globals.css. */
 export function LandscapeShell({ children }: { children: React.ReactNode }) {
   return <div className="landscape-shell h-full w-full">{children}</div>;
 }

--- a/apps/stonksville/src/components/landscape-lock.tsx
+++ b/apps/stonksville/src/components/landscape-lock.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Requests landscape orientation via the Screen Orientation API on mobile.
+ * Falls back to showing a "rotate your device" prompt when the API isn't
+ * available and the user is in portrait.
+ */
+export function LandscapeLock() {
+  const [showPrompt, setShowPrompt] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 768px)");
+    if (!mq.matches) return;
+
+    // Try the standard Screen Orientation API.
+    // lock() isn't in all TS lib types yet, so we cast through unknown.
+    const orientation = screen.orientation as ScreenOrientation & {
+      lock?: (type: string) => Promise<void>;
+    };
+    if (orientation?.lock) {
+      orientation.lock("landscape").catch(() => {
+        // lock() rejected — browser doesn't support it or we're not fullscreen.
+        // Fall back to the portrait prompt.
+        checkOrientation();
+      });
+    } else {
+      checkOrientation();
+    }
+
+    function checkOrientation() {
+      const isPortrait = window.matchMedia(
+        "(orientation: portrait)",
+      ).matches;
+      setShowPrompt(isPortrait);
+    }
+
+    // Update prompt when orientation changes (e.g. user rotates phone)
+    const orientationMq = window.matchMedia("(orientation: portrait)");
+    const handler = (e: MediaQueryListEvent) => setShowPrompt(e.matches);
+    orientationMq.addEventListener("change", handler);
+
+    return () => {
+      orientationMq.removeEventListener("change", handler);
+      if (orientation?.unlock) {
+        try {
+          orientation.unlock();
+        } catch {
+          // ignore
+        }
+      }
+    };
+  }, []);
+
+  if (!showPrompt) return null;
+
+  return (
+    <div className="fixed inset-0 z-[99999] flex items-center justify-center bg-black/90">
+      <div className="text-center text-white">
+        <div className="mb-4 text-5xl">📱</div>
+        <p className="text-lg font-bold">Rotate your device</p>
+        <p className="mt-1 text-sm text-white/60">
+          This game is best played in landscape
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/stonksville/src/components/trading-chart.tsx
+++ b/apps/stonksville/src/components/trading-chart.tsx
@@ -26,7 +26,13 @@ import {
 /** Visible time window for Liveline (seconds) */
 const CHART_WINDOW = 60;
 /** Future zone as fraction of total width */
-const FUTURE_RATIO = 0.5;
+const FUTURE_RATIO_MOBILE = 0.5;
+const FUTURE_RATIO_DESKTOP = 0.35;
+const MOBILE_BREAKPOINT = 768;
+
+function getFutureRatio(width: number): number {
+  return width <= MOBILE_BREAKPOINT ? FUTURE_RATIO_MOBILE : FUTURE_RATIO_DESKTOP;
+}
 /** Half a grid cell in ms */
 const HALF_CELL_MS = (GRID_CELL_SECONDS * 1000) / 2;
 /** Fixed price range (half above + half below current price) */
@@ -89,7 +95,7 @@ function computeDims(
   const padTop = 0;
   const padBottom = 28;
   const padLeft = 2;
-  const padRight = width * FUTURE_RATIO;
+  const padRight = width * getFutureRatio(width);
 
   const chartWidth = width - padLeft - padRight;
   const timePerPx = CHART_WINDOW / chartWidth;
@@ -324,7 +330,7 @@ export function TradingChart() {
       if (entry) {
         const { width, height } = entry.contentRect;
         sizeRef.current = { width, height };
-        setRightPad(Math.round(width * FUTURE_RATIO) || 200);
+        setRightPad(Math.round(width * getFutureRatio(width)) || 200);
       }
     });
     observer.observe(container);

--- a/apps/stonksville/src/components/trading-chart.tsx
+++ b/apps/stonksville/src/components/trading-chart.tsx
@@ -499,6 +499,12 @@ export function TradingChart() {
               color: "#000000",
             },
           ]);
+          // textBalloons appends to document.body which is rotated on mobile;
+          // move the container to <html> so position:fixed works correctly
+          const balloonEl = document.body.querySelector("text-balloons");
+          if (balloonEl) {
+            document.documentElement.appendChild(balloonEl);
+          }
           if (container) {
             const localX = timeToX(b.targetTime, dims);
             const localY = priceToY(b.priceLevel, dims);
@@ -529,7 +535,7 @@ export function TradingChart() {
   }, []);
 
   const tryPlaceAt = useCallback(
-    (x: number, y: number, screenX?: number, screenY?: number) => {
+    (x: number, y: number) => {
       const dims = getClickDims();
       const price = engineRef.current?.getCurrentPrice() ?? 5200;
       const snapped = snapToGrid(yToPrice(y, dims), xToTime(x, dims));
@@ -538,8 +544,14 @@ export function TradingChart() {
       lastPlacedCellRef.current = cellKey;
       const prev = stateRef.current;
       stateRef.current = placeBlock(prev, price, snapped.price, snapped.time);
-      if (stateRef.current !== prev && screenX != null && screenY != null) {
-        fireConfetti(screenX, screenY, { particleCount: 20, size: 0.6 });
+      if (stateRef.current !== prev) {
+        const container = containerRef.current;
+        if (container) {
+          const localX = timeToX(snapped.time, dims);
+          const localY = priceToY(snapped.price, dims);
+          const screen = localToScreen(container, localX, localY);
+          fireConfetti(screen.x, screen.y, { particleCount: 20, size: 0.6 });
+        }
       }
     },
     [getClickDims],
@@ -550,9 +562,7 @@ export function TradingChart() {
       e.currentTarget.setPointerCapture(e.pointerId);
       draggingRef.current = true;
       lastPlacedCellRef.current = null;
-      const x = e.nativeEvent.offsetX;
-      const y = e.nativeEvent.offsetY;
-      tryPlaceAt(x, y, e.clientX, e.clientY);
+      tryPlaceAt(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
     },
     [tryPlaceAt],
   );
@@ -563,7 +573,7 @@ export function TradingChart() {
       const y = e.nativeEvent.offsetY;
       hoverRef.current = { x, y };
       if (draggingRef.current) {
-        tryPlaceAt(x, y, e.clientX, e.clientY);
+        tryPlaceAt(x, y);
       }
     },
     [tryPlaceAt],
@@ -571,6 +581,13 @@ export function TradingChart() {
 
   const handlePointerUp = useCallback((e: React.PointerEvent<HTMLElement>) => {
     e.currentTarget.releasePointerCapture(e.pointerId);
+    draggingRef.current = false;
+    lastPlacedCellRef.current = null;
+  }, []);
+
+  const handlePointerCancel = useCallback((e: React.PointerEvent<HTMLElement>) => {
+    e.currentTarget.releasePointerCapture(e.pointerId);
+    hoverRef.current = null;
     draggingRef.current = false;
     lastPlacedCellRef.current = null;
   }, []);
@@ -637,6 +654,7 @@ export function TradingChart() {
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
         onPointerLeave={handlePointerLeave}
       />
 

--- a/apps/stonksville/src/components/trading-chart.tsx
+++ b/apps/stonksville/src/components/trading-chart.tsx
@@ -30,13 +30,13 @@ const FUTURE_RATIO_MOBILE = 0.5;
 const FUTURE_RATIO_DESKTOP = 0.35;
 const MOBILE_BREAKPOINT = 768;
 
-function isMobile(): boolean {
-  return typeof window !== "undefined" &&
-    window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT}px)`).matches;
-}
+const mobileQuery =
+  typeof window !== "undefined"
+    ? window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT}px)`)
+    : null;
 
 function getFutureRatio(): number {
-  return isMobile() ? FUTURE_RATIO_MOBILE : FUTURE_RATIO_DESKTOP;
+  return mobileQuery?.matches ? FUTURE_RATIO_MOBILE : FUTURE_RATIO_DESKTOP;
 }
 /** Half a grid cell in ms */
 const HALF_CELL_MS = (GRID_CELL_SECONDS * 1000) / 2;
@@ -573,6 +573,7 @@ export function TradingChart() {
       e.currentTarget.releasePointerCapture(e.pointerId);
       draggingRef.current = false;
       lastPlacedCellRef.current = null;
+      if (e.pointerType !== "mouse") hoverRef.current = null;
     },
     [],
   );

--- a/apps/stonksville/src/components/trading-chart.tsx
+++ b/apps/stonksville/src/components/trading-chart.tsx
@@ -26,7 +26,7 @@ import {
 /** Visible time window for Liveline (seconds) */
 const CHART_WINDOW = 60;
 /** Future zone as fraction of total width */
-const FUTURE_RATIO = 0.35;
+const FUTURE_RATIO = 0.5;
 /** Half a grid cell in ms */
 const HALF_CELL_MS = (GRID_CELL_SECONDS * 1000) / 2;
 /** Fixed price range (half above + half below current price) */
@@ -509,7 +509,7 @@ export function TradingChart() {
   }, []);
 
   const tryPlaceAt = useCallback(
-    (x: number, y: number) => {
+    (x: number, y: number, screenX?: number, screenY?: number) => {
       const dims = getClickDims();
       const price = engineRef.current?.getCurrentPrice() ?? 5200;
       const snapped = snapToGrid(yToPrice(y, dims), xToTime(x, dims));
@@ -518,89 +518,44 @@ export function TradingChart() {
       lastPlacedCellRef.current = cellKey;
       const prev = stateRef.current;
       stateRef.current = placeBlock(prev, price, snapped.price, snapped.time);
-      if (stateRef.current !== prev) {
-        const container = containerRef.current;
-        if (container) {
-          const rect = container.getBoundingClientRect();
-          const screenX = rect.left + timeToX(snapped.time, dims);
-          const screenY = rect.top + priceToY(snapped.price, dims);
-          fireConfetti(screenX, screenY, { particleCount: 20, size: 0.6 });
-        }
+      if (stateRef.current !== prev && screenX != null && screenY != null) {
+        fireConfetti(screenX, screenY, { particleCount: 20, size: 0.6 });
       }
     },
     [getClickDims],
   );
 
-  const handleMouseDown = useCallback(
-    (e: React.MouseEvent<HTMLElement>) => {
-      const container = containerRef.current;
-      if (!container) return;
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      e.currentTarget.setPointerCapture(e.pointerId);
       draggingRef.current = true;
       lastPlacedCellRef.current = null;
-      const rect = container.getBoundingClientRect();
-      tryPlaceAt(e.clientX - rect.left, e.clientY - rect.top);
+      const x = e.nativeEvent.offsetX;
+      const y = e.nativeEvent.offsetY;
+      tryPlaceAt(x, y, e.clientX, e.clientY);
     },
     [tryPlaceAt],
   );
 
-  const handleMouseMove = useCallback(
-    (e: React.MouseEvent<HTMLElement>) => {
-      const container = containerRef.current;
-      if (!container) return;
-      const rect = container.getBoundingClientRect();
-      const x = e.clientX - rect.left;
-      const y = e.clientY - rect.top;
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      const x = e.nativeEvent.offsetX;
+      const y = e.nativeEvent.offsetY;
       hoverRef.current = { x, y };
       if (draggingRef.current) {
-        tryPlaceAt(x, y);
+        tryPlaceAt(x, y, e.clientX, e.clientY);
       }
     },
     [tryPlaceAt],
   );
 
-  const handleMouseUp = useCallback(() => {
+  const handlePointerUp = useCallback((e: React.PointerEvent<HTMLElement>) => {
+    e.currentTarget.releasePointerCapture(e.pointerId);
     draggingRef.current = false;
     lastPlacedCellRef.current = null;
   }, []);
 
-  const handleMouseLeave = useCallback(() => {
-    hoverRef.current = null;
-    draggingRef.current = false;
-    lastPlacedCellRef.current = null;
-  }, []);
-
-  const handleTouchStart = useCallback(
-    (e: React.TouchEvent<HTMLElement>) => {
-      const container = containerRef.current;
-      if (!container) return;
-      const touch = e.touches[0];
-      if (!touch) return;
-      draggingRef.current = true;
-      lastPlacedCellRef.current = null;
-      const rect = container.getBoundingClientRect();
-      tryPlaceAt(touch.clientX - rect.left, touch.clientY - rect.top);
-    },
-    [tryPlaceAt],
-  );
-
-  const handleTouchMove = useCallback(
-    (e: React.TouchEvent<HTMLElement>) => {
-      const container = containerRef.current;
-      if (!container) return;
-      const touch = e.touches[0];
-      if (!touch) return;
-      const rect = container.getBoundingClientRect();
-      const x = touch.clientX - rect.left;
-      const y = touch.clientY - rect.top;
-      hoverRef.current = { x, y };
-      if (draggingRef.current) {
-        tryPlaceAt(x, y);
-      }
-    },
-    [tryPlaceAt],
-  );
-
-  const handleTouchEnd = useCallback(() => {
+  const handlePointerLeave = useCallback(() => {
     hoverRef.current = null;
     draggingRef.current = false;
     lastPlacedCellRef.current = null;
@@ -658,13 +613,11 @@ export function TradingChart() {
       {/* Click capture (on top) */}
       <div
         className="absolute inset-0 z-20 cursor-crosshair"
-        onMouseDown={handleMouseDown}
-        onMouseMove={handleMouseMove}
-        onMouseUp={handleMouseUp}
-        onMouseLeave={handleMouseLeave}
-        onTouchStart={handleTouchStart}
-        onTouchMove={handleTouchMove}
-        onTouchEnd={handleTouchEnd}
+        style={{ touchAction: "none" }}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerLeave={handlePointerLeave}
       />
 
       {/* HUD */}

--- a/apps/stonksville/src/components/trading-chart.tsx
+++ b/apps/stonksville/src/components/trading-chart.tsx
@@ -74,6 +74,20 @@ function yToPrice(y: number, dims: OverlayDims): number {
   return dims.priceMax + frac * (dims.priceMin - dims.priceMax);
 }
 
+/** Convert element-local coordinates to screen coordinates, accounting for CSS transforms. */
+function localToScreen(
+  el: HTMLElement,
+  lx: number,
+  ly: number,
+): { x: number; y: number } {
+  const temp = document.createElement("div");
+  temp.style.cssText = `position:absolute;left:${lx}px;top:${ly}px;width:0;height:0;pointer-events:none;visibility:hidden`;
+  el.appendChild(temp);
+  const r = temp.getBoundingClientRect();
+  el.removeChild(temp);
+  return { x: r.left, y: r.top };
+}
+
 function snapToGrid(
   price: number,
   time: number,
@@ -465,7 +479,6 @@ export function TradingChart() {
 
       const prevById = new Map(prev.map((b) => [b.id, b]));
       const container = containerRef.current;
-      const rect = container?.getBoundingClientRect();
       const { width, height } = sizeRef.current;
       const center = rangeCenterRef.current;
       const dims = computeDims(
@@ -486,10 +499,11 @@ export function TradingChart() {
               color: "#000000",
             },
           ]);
-          if (rect) {
-            const bx = rect.left + timeToX(b.targetTime, dims);
-            const by = rect.top + priceToY(b.priceLevel, dims);
-            fireConfetti(bx, by, {
+          if (container) {
+            const localX = timeToX(b.targetTime, dims);
+            const localY = priceToY(b.priceLevel, dims);
+            const screen = localToScreen(container, localX, localY);
+            fireConfetti(screen.x, screen.y, {
               particleCount: 12,
               startVelocity: 8,
               spread: 360,

--- a/apps/stonksville/src/components/trading-chart.tsx
+++ b/apps/stonksville/src/components/trading-chart.tsx
@@ -96,11 +96,12 @@ function computeDims(
   now: number,
   priceMin: number,
   priceMax: number,
+  futureRatio: number,
 ): OverlayDims {
   const padTop = 0;
   const padBottom = 28;
   const padLeft = 2;
-  const padRight = width * getFutureRatio();
+  const padRight = width * futureRatio;
 
   const chartWidth = width - padLeft - padRight;
   const timePerPx = CHART_WINDOW / chartWidth;
@@ -444,7 +445,7 @@ export function TradingChart() {
         setBlockCount(next.blocks.length);
       }
 
-      const dims = computeDims(width, height, now, min, max);
+      const dims = computeDims(width, height, now, min, max, getFutureRatio());
 
       const hover = hoverRef.current;
       drawOverlay(
@@ -479,6 +480,7 @@ export function TradingChart() {
         Date.now(),
         center - PRICE_RANGE_HALF,
         center + PRICE_RANGE_HALF,
+        getFutureRatio(),
       );
 
       for (const b of next.blocks) {
@@ -519,7 +521,7 @@ export function TradingChart() {
     const { width, height } = sizeRef.current;
     const now = Date.now();
     const center = rangeCenterRef.current;
-    return computeDims(width, height, now, center - PRICE_RANGE_HALF, center + PRICE_RANGE_HALF);
+    return computeDims(width, height, now, center - PRICE_RANGE_HALF, center + PRICE_RANGE_HALF, getFutureRatio());
   }, []);
 
   const tryPlaceAt = useCallback(
@@ -546,6 +548,8 @@ export function TradingChart() {
     [getClickDims],
   );
 
+  // setPointerCapture retargets subsequent events to this element;
+  // offsetX/offsetY remain relative to the capture target's padding box.
   const handlePointerDown = useCallback(
     (e: React.PointerEvent<HTMLElement>) => {
       e.currentTarget.setPointerCapture(e.pointerId);

--- a/apps/stonksville/src/components/trading-chart.tsx
+++ b/apps/stonksville/src/components/trading-chart.tsx
@@ -83,18 +83,19 @@ function localToScreen(
   const rect = el.getBoundingClientRect();
   const bodyTransform = getComputedStyle(document.body).transform;
 
-  if (!bodyTransform || bodyTransform === "none") {
-    return { x: rect.left + lx, y: rect.top + ly };
+  // Only apply rotation mapping for the 90deg landscape hack.
+  // Any other transform (or none) falls through to the simple offset path.
+  if (bodyTransform && /rotate\(90deg\)/.test(document.body.style.transform)) {
+    // Local x maps to screen y, local y maps to inverted screen x.
+    const ow = el.offsetWidth;
+    const oh = el.offsetHeight;
+    return {
+      x: rect.right - (ly / oh) * rect.width,
+      y: rect.top + (lx / ow) * rect.height,
+    };
   }
 
-  // Body has the rotate(90deg) landscape hack.
-  // Local x maps to screen y, local y maps to inverted screen x.
-  const ow = el.offsetWidth;
-  const oh = el.offsetHeight;
-  return {
-    x: rect.right - (ly / oh) * rect.width,
-    y: rect.top + (lx / ow) * rect.height,
-  };
+  return { x: rect.left + lx, y: rect.top + ly };
 }
 
 function snapToGrid(
@@ -480,6 +481,23 @@ export function TradingChart() {
 
   // Track previous block states for touch detection (balloon/confetti effects)
   const prevBlocksRef = useRef<Block[]>([]);
+
+  // textBalloons appends to document.body which is rotated on mobile;
+  // observe and move new <text-balloons> elements to <html> so position:fixed works
+  useEffect(() => {
+    const observer = new MutationObserver((mutations) => {
+      for (const m of mutations) {
+        for (const node of m.addedNodes) {
+          if (node instanceof HTMLElement && node.tagName === "TEXT-BALLOONS") {
+            document.documentElement.appendChild(node);
+          }
+        }
+      }
+    });
+    observer.observe(document.body, { childList: true });
+    return () => observer.disconnect();
+  }, []);
+
   useEffect(() => {
     const interval = setInterval(() => {
       const next = stateRef.current;
@@ -508,12 +526,6 @@ export function TradingChart() {
               color: "#000000",
             },
           ]);
-          // textBalloons appends to document.body which is rotated on mobile;
-          // move the container to <html> so position:fixed works correctly
-          const balloonEl = document.body.querySelector("text-balloons");
-          if (balloonEl) {
-            document.documentElement.appendChild(balloonEl);
-          }
           if (container) {
             const localX = timeToX(b.targetTime, dims);
             const localY = priceToY(b.priceLevel, dims);
@@ -588,11 +600,14 @@ export function TradingChart() {
     [tryPlaceAt],
   );
 
-  const handlePointerUp = useCallback((e: React.PointerEvent<HTMLElement>) => {
-    e.currentTarget.releasePointerCapture(e.pointerId);
-    draggingRef.current = false;
-    lastPlacedCellRef.current = null;
-  }, []);
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+      draggingRef.current = false;
+      lastPlacedCellRef.current = null;
+    },
+    [],
+  );
 
   const resetPointerState = useCallback(() => {
     hoverRef.current = null;
@@ -600,10 +615,13 @@ export function TradingChart() {
     lastPlacedCellRef.current = null;
   }, []);
 
-  const handlePointerCancel = useCallback((e: React.PointerEvent<HTMLElement>) => {
-    e.currentTarget.releasePointerCapture(e.pointerId);
-    resetPointerState();
-  }, [resetPointerState]);
+  const handlePointerCancel = useCallback(
+    (e: React.PointerEvent<HTMLElement>) => {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+      resetPointerState();
+    },
+    [resetPointerState],
+  );
 
   const handleReset = useCallback(() => {
     stateRef.current = createInitialState();

--- a/apps/stonksville/src/components/trading-chart.tsx
+++ b/apps/stonksville/src/components/trading-chart.tsx
@@ -74,30 +74,6 @@ function yToPrice(y: number, dims: OverlayDims): number {
   return dims.priceMax + frac * (dims.priceMin - dims.priceMax);
 }
 
-/** Convert element-local coordinates to screen coordinates, accounting for CSS transforms. */
-function localToScreen(
-  el: HTMLElement,
-  lx: number,
-  ly: number,
-): { x: number; y: number } {
-  const rect = el.getBoundingClientRect();
-  const computed = getComputedStyle(document.body).transform;
-
-  // Detect the 90deg CW landscape rotation hack via the resolved matrix.
-  // rotate(90deg) computes to matrix(0, 1, -1, 0, ...).
-  if (computed && /matrix\(0,\s*1/.test(computed)) {
-    // Local x maps to screen y, local y maps to inverted screen x.
-    const ow = el.offsetWidth;
-    const oh = el.offsetHeight;
-    return {
-      x: rect.right - (ly / oh) * rect.width,
-      y: rect.top + (lx / ow) * rect.height,
-    };
-  }
-
-  return { x: rect.left + lx, y: rect.top + ly };
-}
-
 function snapToGrid(
   price: number,
   time: number,
@@ -481,23 +457,6 @@ export function TradingChart() {
 
   // Track previous block states for touch detection (balloon/confetti effects)
   const prevBlocksRef = useRef<Block[]>([]);
-
-  // textBalloons appends to document.body which is rotated on mobile;
-  // observe and move new <text-balloons> elements to <html> so position:fixed works
-  useEffect(() => {
-    const observer = new MutationObserver((mutations) => {
-      for (const m of mutations) {
-        for (const node of m.addedNodes) {
-          if (node instanceof HTMLElement && node.tagName === "TEXT-BALLOONS") {
-            document.documentElement.appendChild(node);
-          }
-        }
-      }
-    });
-    observer.observe(document.body, { childList: true });
-    return () => observer.disconnect();
-  }, []);
-
   useEffect(() => {
     const interval = setInterval(() => {
       const next = stateRef.current;
@@ -506,6 +465,7 @@ export function TradingChart() {
 
       const prevById = new Map(prev.map((b) => [b.id, b]));
       const container = containerRef.current;
+      const rect = container?.getBoundingClientRect();
       const { width, height } = sizeRef.current;
       const center = rangeCenterRef.current;
       const dims = computeDims(
@@ -526,11 +486,10 @@ export function TradingChart() {
               color: "#000000",
             },
           ]);
-          if (container) {
-            const localX = timeToX(b.targetTime, dims);
-            const localY = priceToY(b.priceLevel, dims);
-            const screen = localToScreen(container, localX, localY);
-            fireConfetti(screen.x, screen.y, {
+          if (rect) {
+            const bx = rect.left + timeToX(b.targetTime, dims);
+            const by = rect.top + priceToY(b.priceLevel, dims);
+            fireConfetti(bx, by, {
               particleCount: 12,
               startVelocity: 8,
               spread: 360,
@@ -568,10 +527,10 @@ export function TradingChart() {
       if (stateRef.current !== prev) {
         const container = containerRef.current;
         if (container) {
-          const localX = timeToX(snapped.time, dims);
-          const localY = priceToY(snapped.price, dims);
-          const screen = localToScreen(container, localX, localY);
-          fireConfetti(screen.x, screen.y, { particleCount: 20, size: 0.6 });
+          const rect = container.getBoundingClientRect();
+          const screenX = rect.left + timeToX(snapped.time, dims);
+          const screenY = rect.top + priceToY(snapped.price, dims);
+          fireConfetti(screenX, screenY, { particleCount: 20, size: 0.6 });
         }
       }
     },

--- a/apps/stonksville/src/components/trading-chart.tsx
+++ b/apps/stonksville/src/components/trading-chart.tsx
@@ -81,11 +81,11 @@ function localToScreen(
   ly: number,
 ): { x: number; y: number } {
   const rect = el.getBoundingClientRect();
-  const bodyTransform = getComputedStyle(document.body).transform;
+  const computed = getComputedStyle(document.body).transform;
 
-  // Only apply rotation mapping for the 90deg landscape hack.
-  // Any other transform (or none) falls through to the simple offset path.
-  if (bodyTransform && /rotate\(90deg\)/.test(document.body.style.transform)) {
+  // Detect the 90deg CW landscape rotation hack via the resolved matrix.
+  // rotate(90deg) computes to matrix(0, 1, -1, 0, ...).
+  if (computed && /matrix\(0,\s*1/.test(computed)) {
     // Local x maps to screen y, local y maps to inverted screen x.
     const ow = el.offsetWidth;
     const oh = el.offsetHeight;

--- a/apps/stonksville/src/components/trading-chart.tsx
+++ b/apps/stonksville/src/components/trading-chart.tsx
@@ -30,8 +30,13 @@ const FUTURE_RATIO_MOBILE = 0.5;
 const FUTURE_RATIO_DESKTOP = 0.35;
 const MOBILE_BREAKPOINT = 768;
 
-function getFutureRatio(width: number): number {
-  return width <= MOBILE_BREAKPOINT ? FUTURE_RATIO_MOBILE : FUTURE_RATIO_DESKTOP;
+function isMobile(): boolean {
+  return typeof window !== "undefined" &&
+    window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT}px)`).matches;
+}
+
+function getFutureRatio(): number {
+  return isMobile() ? FUTURE_RATIO_MOBILE : FUTURE_RATIO_DESKTOP;
 }
 /** Half a grid cell in ms */
 const HALF_CELL_MS = (GRID_CELL_SECONDS * 1000) / 2;
@@ -95,7 +100,7 @@ function computeDims(
   const padTop = 0;
   const padBottom = 28;
   const padLeft = 2;
-  const padRight = width * getFutureRatio(width);
+  const padRight = width * getFutureRatio();
 
   const chartWidth = width - padLeft - padRight;
   const timePerPx = CHART_WINDOW / chartWidth;
@@ -294,6 +299,7 @@ function drawBlock(
 
 export function TradingChart() {
   const containerRef = useRef<HTMLDivElement>(null);
+  const confettiLayerRef = useRef<HTMLDivElement>(null);
   const overlayRef = useRef<HTMLCanvasElement>(null);
   const engineRef = useRef<PriceEngine | null>(null);
   const stateRef = useRef(createInitialState());
@@ -330,7 +336,7 @@ export function TradingChart() {
       if (entry) {
         const { width, height } = entry.contentRect;
         sizeRef.current = { width, height };
-        setRightPad(Math.round(width * getFutureRatio(width)) || 200);
+        setRightPad(Math.round(width * getFutureRatio()) || 200);
       }
     });
     observer.observe(container);
@@ -464,8 +470,7 @@ export function TradingChart() {
       if (next.blocks === prev) return;
 
       const prevById = new Map(prev.map((b) => [b.id, b]));
-      const container = containerRef.current;
-      const rect = container?.getBoundingClientRect();
+      const confettiLayer = confettiLayerRef.current;
       const { width, height } = sizeRef.current;
       const center = rangeCenterRef.current;
       const dims = computeDims(
@@ -486,18 +491,21 @@ export function TradingChart() {
               color: "#000000",
             },
           ]);
-          if (rect) {
-            const bx = rect.left + timeToX(b.targetTime, dims);
-            const by = rect.top + priceToY(b.priceLevel, dims);
-            fireConfetti(bx, by, {
-              particleCount: 12,
-              startVelocity: 8,
-              spread: 360,
-              decay: 0.94,
-              gravity: 0.4,
-              size: 0.7,
-              emojis: ["💰"],
-            });
+          if (confettiLayer) {
+            fireConfetti(
+              timeToX(b.targetTime, dims),
+              priceToY(b.priceLevel, dims),
+              {
+                particleCount: 12,
+                startVelocity: 8,
+                spread: 360,
+                decay: 0.94,
+                gravity: 0.4,
+                size: 0.7,
+                emojis: ["💰"],
+                parent: confettiLayer,
+              },
+            );
           }
         }
       }
@@ -525,12 +533,13 @@ export function TradingChart() {
       const prev = stateRef.current;
       stateRef.current = placeBlock(prev, price, snapped.price, snapped.time);
       if (stateRef.current !== prev) {
-        const container = containerRef.current;
-        if (container) {
-          const rect = container.getBoundingClientRect();
-          const screenX = rect.left + timeToX(snapped.time, dims);
-          const screenY = rect.top + priceToY(snapped.price, dims);
-          fireConfetti(screenX, screenY, { particleCount: 20, size: 0.6 });
+        const confettiLayer = confettiLayerRef.current;
+        if (confettiLayer) {
+          fireConfetti(
+            timeToX(snapped.time, dims),
+            priceToY(snapped.price, dims),
+            { particleCount: 20, size: 0.6, parent: confettiLayer },
+          );
         }
       }
     },
@@ -640,6 +649,12 @@ export function TradingChart() {
         onPointerUp={handlePointerUp}
         onPointerCancel={handlePointerCancel}
         onPointerLeave={resetPointerState}
+      />
+
+      {/* Confetti layer — inside the container so coordinates are chart-local */}
+      <div
+        ref={confettiLayerRef}
+        className="pointer-events-none absolute inset-0 z-25 overflow-hidden"
       />
 
       {/* HUD */}

--- a/apps/stonksville/src/components/trading-chart.tsx
+++ b/apps/stonksville/src/components/trading-chart.tsx
@@ -80,12 +80,21 @@ function localToScreen(
   lx: number,
   ly: number,
 ): { x: number; y: number } {
-  const temp = document.createElement("div");
-  temp.style.cssText = `position:absolute;left:${lx}px;top:${ly}px;width:0;height:0;pointer-events:none;visibility:hidden`;
-  el.appendChild(temp);
-  const r = temp.getBoundingClientRect();
-  el.removeChild(temp);
-  return { x: r.left, y: r.top };
+  const rect = el.getBoundingClientRect();
+  const bodyTransform = getComputedStyle(document.body).transform;
+
+  if (!bodyTransform || bodyTransform === "none") {
+    return { x: rect.left + lx, y: rect.top + ly };
+  }
+
+  // Body has the rotate(90deg) landscape hack.
+  // Local x maps to screen y, local y maps to inverted screen x.
+  const ow = el.offsetWidth;
+  const oh = el.offsetHeight;
+  return {
+    x: rect.right - (ly / oh) * rect.width,
+    y: rect.top + (lx / ow) * rect.height,
+  };
 }
 
 function snapToGrid(
@@ -585,18 +594,16 @@ export function TradingChart() {
     lastPlacedCellRef.current = null;
   }, []);
 
-  const handlePointerCancel = useCallback((e: React.PointerEvent<HTMLElement>) => {
-    e.currentTarget.releasePointerCapture(e.pointerId);
+  const resetPointerState = useCallback(() => {
     hoverRef.current = null;
     draggingRef.current = false;
     lastPlacedCellRef.current = null;
   }, []);
 
-  const handlePointerLeave = useCallback(() => {
-    hoverRef.current = null;
-    draggingRef.current = false;
-    lastPlacedCellRef.current = null;
-  }, []);
+  const handlePointerCancel = useCallback((e: React.PointerEvent<HTMLElement>) => {
+    e.currentTarget.releasePointerCapture(e.pointerId);
+    resetPointerState();
+  }, [resetPointerState]);
 
   const handleReset = useCallback(() => {
     stateRef.current = createInitialState();
@@ -655,7 +662,7 @@ export function TradingChart() {
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
         onPointerCancel={handlePointerCancel}
-        onPointerLeave={handlePointerLeave}
+        onPointerLeave={resetPointerState}
       />
 
       {/* HUD */}

--- a/apps/stonksville/src/lib/confetti.ts
+++ b/apps/stonksville/src/lib/confetti.ts
@@ -135,7 +135,7 @@ export function fireConfetti(
   const container = document.createElement("div");
   container.style.cssText =
     "position:fixed;top:0;left:0;width:100vw;height:100vh;pointer-events:none;z-index:99999;overflow:hidden";
-  document.body.appendChild(container);
+  document.documentElement.appendChild(container);
 
   const ticks = Math.round(duration * 60);
 

--- a/apps/stonksville/src/lib/confetti.ts
+++ b/apps/stonksville/src/lib/confetti.ts
@@ -135,7 +135,7 @@ export function fireConfetti(
   const container = document.createElement("div");
   container.style.cssText =
     "position:fixed;top:0;left:0;width:100vw;height:100vh;pointer-events:none;z-index:99999;overflow:hidden";
-  document.documentElement.appendChild(container);
+  document.body.appendChild(container);
 
   const ticks = Math.round(duration * 60);
 

--- a/apps/stonksville/src/lib/confetti.ts
+++ b/apps/stonksville/src/lib/confetti.ts
@@ -101,7 +101,10 @@ function computeKeyframes(params: {
 }
 
 /**
- * Fire confetti from a specific screen position.
+ * Fire confetti from a specific position.
+ * When `parent` is provided, confetti renders inside that element using
+ * position:absolute (coordinates are parent-local). Otherwise falls back
+ * to a viewport-fixed overlay on document.body.
  */
 export function fireConfetti(
   originX: number,
@@ -117,6 +120,7 @@ export function fireConfetti(
     size?: number;
     colors?: string[];
     emojis?: string[];
+    parent?: HTMLElement;
   } = {},
 ) {
   const {
@@ -130,12 +134,19 @@ export function fireConfetti(
     size = 1,
     colors = COLORS,
     emojis,
+    parent,
   } = opts;
 
   const container = document.createElement("div");
-  container.style.cssText =
-    "position:fixed;top:0;left:0;width:100vw;height:100vh;pointer-events:none;z-index:99999;overflow:hidden";
-  document.body.appendChild(container);
+  if (parent) {
+    container.style.cssText =
+      "position:absolute;inset:0;pointer-events:none;z-index:99999;overflow:hidden";
+    parent.appendChild(container);
+  } else {
+    container.style.cssText =
+      "position:fixed;top:0;left:0;width:100vw;height:100vh;pointer-events:none;z-index:99999;overflow:hidden";
+    document.body.appendChild(container);
+  }
 
   const ticks = Math.round(duration * 60);
 


### PR DESCRIPTION
Switch from mouse+touch events to pointer events using offsetX/offsetY
which correctly account for CSS transforms (the body rotate(90deg) hack
for forcing landscape). Also change FUTURE_RATIO from 0.35 to 0.5 so
the chart line takes up 50% of the screen width.

https://claude.ai/code/session_016esddxEPedYgYWnevo78Hg