### PR TITLE
fix(policingice): page crash from react-tweet entities TypeError

### DIFF
--- a/apps/policingice/package.json
+++ b/apps/policingice/package.json
@@ -27,7 +27,7 @@
     "next-themes": "^0.4.6",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "react-tweet": "^3.3.0",
+    "react-tweet": "^3.3.1",
     "sonner": "^2.0.7",
     "tailwindcss": "catalog:",
     "zod": "^4.4.3"

--- a/apps/policingice/src/components/keyboard-shortcuts-provider.tsx
+++ b/apps/policingice/src/components/keyboard-shortcuts-provider.tsx
@@ -189,6 +189,16 @@ export const KeyboardShortcutsProvider = ({ children }: KeyboardShortcutsProvide
 const KeyboardShortcutsHelp = () => {
   const [aboutOpen, setAboutOpen] = useState(false);
   const { resolvedTheme, setTheme } = useTheme();
+  // resolvedTheme is undefined on the server; render theme-dependent UI only
+  // after mount to avoid a hydration mismatch.
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- client-only mounting guard for SSR compatibility
+    setMounted(true);
+  }, []);
+
+  const isDark = mounted && resolvedTheme === "dark";
 
   return (
     <div className="fixed right-4 bottom-4 hidden text-xs text-muted-foreground sm:block">
@@ -239,16 +249,12 @@ const KeyboardShortcutsHelp = () => {
         </a>
         <span className="text-muted-foreground/40">·</span>
         <button
-          onClick={() => setTheme(resolvedTheme === "dark" ? "light" : "dark")}
+          onClick={() => setTheme(isDark ? "light" : "dark")}
           className="cursor-pointer hover:text-foreground"
           aria-label="Toggle theme"
-          title={resolvedTheme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+          title={isDark ? "Switch to light mode" : "Switch to dark mode"}
         >
-          {resolvedTheme === "dark" ? (
-            <Sun className="h-3.5 w-3.5" />
-          ) : (
-            <Moon className="h-3.5 w-3.5" />
-          )}
+          {isDark ? <Sun className="h-3.5 w-3.5" /> : <Moon className="h-3.5 w-3.5" />}
         </button>
       </div>
       <div className="flex items-center gap-3">

--- a/apps/policingice/src/components/video-embed.tsx
+++ b/apps/policingice/src/components/video-embed.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { lazy, Suspense, useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import { Component, lazy, Suspense, useEffect, useState } from "react";
 
 import type { VideoPlatform } from "@/db/drizzle-schema";
 import { useTheme } from "@/components/theme";
@@ -34,6 +35,23 @@ const FallbackLink = ({ url, platform }: { url: string; platform: VideoPlatform 
     </a>
   );
 };
+
+type EmbedErrorBoundaryProps = { fallback: ReactNode; children: ReactNode };
+
+// Third-party embeds (react-tweet especially) can throw at render time when a
+// platform changes its API response shape. Contain the blast radius to the
+// embed instead of unmounting the whole page.
+class EmbedErrorBoundary extends Component<EmbedErrorBoundaryProps, { hasError: boolean }> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    return this.state.hasError ? this.props.fallback : this.props.children;
+  }
+}
 
 const YouTubeEmbed = ({ videoId }: { videoId: string }) => {
   return (
@@ -176,5 +194,11 @@ export const VideoEmbed = ({ url, platform }: VideoEmbedProps) => {
     }
   };
 
-  return <div className="w-full max-w-[550px]">{renderEmbed()}</div>;
+  return (
+    <div className="w-full max-w-[550px]">
+      <EmbedErrorBoundary fallback={<FallbackLink url={url} platform={platform} />}>
+        {renderEmbed()}
+      </EmbedErrorBoundary>
+    </div>
+  );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,7 +238,7 @@ importers:
         version: 10.3.1(react@19.2.6)
       '@vercel/analytics':
         specifier: 'catalog:'
-        version: 2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@vercel/speed-insights':
         specifier: ^2.0.0
         version: 2.0.0(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
@@ -329,7 +329,7 @@ importers:
         version: 0.17.3
       '@vercel/analytics':
         specifier: 'catalog:'
-        version: 2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       ai:
         specifier: ^6.0.191
         version: 6.0.191(zod@4.4.3)
@@ -361,8 +361,8 @@ importers:
         specifier: 'catalog:'
         version: 19.2.6(react@19.2.6)
       react-tweet:
-        specifier: ^3.3.0
-        version: 3.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^3.3.1
+        version: 3.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -4814,8 +4814,8 @@ packages:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
 
-  react-tweet@3.3.0:
-    resolution: {integrity: sha512-gSIG2169ZK7UH6rBzuU+j1xnQbH3IlOTLEkuGrRiJJTMgETik+h+26yHyyVKrLkzwrOaYPk4K3OtEKycqKgNLw==}
+  react-tweet@3.3.1:
+    resolution: {integrity: sha512-0Gj1YgBTe1K85NBMoWBlUc17Rdc67gIJLlacrVgj+3jWIoXpFfxPdZ1U5OnWkkF9zxhphqs2pY1i//JBfP3Qog==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -7538,7 +7538,7 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.6
 
-  '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/analytics@2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
@@ -9381,7 +9381,7 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  react-tweet@3.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  react-tweet@3.3.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@swc/helpers': 0.5.21
       clsx: 2.1.1


### PR DESCRIPTION
## Problem
https://www.policingice.com crashes client-side: `TypeError: entities is not iterable` thrown by react-tweet's `<Tweet>` when X's API returns tweets without `entities`. No error boundary above the embed, so React unmounts the whole page.

Also fixes a hydration mismatch from the theme toggle rendering theme-dependent `title`/icon during SSR.

## Fix
- Bump react-tweet 3.3.0 → 3.3.1 (adds null-guards for missing `entities`)
- `EmbedErrorBoundary` around all video embeds — a throwing embed degrades to the platform fallback link instead of killing the page
- Mount-guard the theme toggle

## Verified
Reproduced crash on local dev (same errors as prod), clean console + full feed render after fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI resilience and dependency patch; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes a **full-page client crash** when X/Twitter embeds throw (e.g. `entities is not iterable` from `react-tweet`) and a **hydration mismatch** on the footer theme control.
> 
> **react-tweet** is bumped **3.3.0 → 3.3.1** so tweets missing `entities` are handled upstream. **`VideoEmbed`** now wraps every platform embed in an **`EmbedErrorBoundary`** that falls back to the existing “open on {platform}” link instead of unmounting the feed. **`KeyboardShortcutsHelp`** defers theme-dependent icon/`title` until after mount so SSR and client agree when `resolvedTheme` is undefined.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1331831f99bce3c581466e85942dd7ba41d1931. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a client-side crash on policingice pages caused by `react-tweet` throwing when tweets lack `entities`. Embeds now fail gracefully to a fallback link, and the theme toggle no longer causes an SSR hydration mismatch.

- **Bug Fixes**
  - Wrap all video embeds with `EmbedErrorBoundary` to show a platform fallback link on render errors.
  - Mount-guard the theme toggle to avoid SSR/CSR mismatch in title/icon rendering.

- **Dependencies**
  - Bump `react-tweet` from `3.3.0` to `3.3.1` (adds null-guards for missing `entities`).

<sup>Written for commit f1331831f99bce3c581466e85942dd7ba41d1931. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/kyh.io/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

