### PR TITLE
refactor: export cn from cnfast across apps

### DIFF
--- a/apps/kwadrants/package.json
+++ b/apps/kwadrants/package.json
@@ -12,6 +12,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "cnfast": "catalog:",
     "konva": "^10.3.0",
     "lucide-react": "catalog:",
     "motion": "^12.40.0",

--- a/apps/kwadrants/src/lib/utils.ts
+++ b/apps/kwadrants/src/lib/utils.ts
@@ -1,3 +1,5 @@
+export { cn } from "cnfast";
+
 export const generateId = () => crypto.randomUUID();
 
 export const downloadURI = (uri: string, name: string) => {

--- a/apps/kyh/package.json
+++ b/apps/kyh/package.json
@@ -17,6 +17,7 @@
     "@use-gesture/react": "^10.3.1",
     "@vercel/analytics": "catalog:",
     "@vercel/speed-insights": "^2.0.0",
+    "cnfast": "catalog:",
     "geist": "^1.7.1",
     "matter-js": "^0.20.0",
     "motion": "^12.40.0",

--- a/apps/kyh/src/lib/utils.ts
+++ b/apps/kyh/src/lib/utils.ts
@@ -1,0 +1,1 @@
+export { cn } from "cnfast";

--- a/apps/policingice/package.json
+++ b/apps/policingice/package.json
@@ -19,6 +19,7 @@
     "@vercel/analytics": "catalog:",
     "ai": "^6.0.191",
     "better-auth": "^1.6.11",
+    "cnfast": "catalog:",
     "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.2",
     "embla-carousel-react": "^8.6.0",

--- a/apps/policingice/src/lib/utils.ts
+++ b/apps/policingice/src/lib/utils.ts
@@ -1,0 +1,1 @@
+export { cn } from "cnfast";

--- a/apps/stonksville/package.json
+++ b/apps/stonksville/package.json
@@ -10,12 +10,11 @@
   },
   "dependencies": {
     "balloons-js": "^0.0.3",
-    "clsx": "^2.1.1",
+    "cnfast": "catalog:",
     "motion": "^12.40.0",
     "next": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "tailwind-merge": "^3.6.0",
     "tailwindcss": "catalog:"
   },
   "devDependencies": {

--- a/apps/stonksville/src/lib/utils.ts
+++ b/apps/stonksville/src/lib/utils.ts
@@ -1,0 +1,1 @@
+export { cn } from "cnfast";

--- a/apps/tc/package.json
+++ b/apps/tc/package.json
@@ -21,6 +21,7 @@
     "@visx/scale": "^3.12.0",
     "@visx/shape": "^3.12.0",
     "@visx/tooltip": "^3.12.0",
+    "cnfast": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-joyride": "^3.1.0",

--- a/apps/tc/src/lib/utils.ts
+++ b/apps/tc/src/lib/utils.ts
@@ -1,0 +1,1 @@
+export { cn } from "cnfast";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ catalogs:
     '@vitejs/plugin-react':
       specifier: ^6.0.2
       version: 6.0.2
+    cnfast:
+      specifier: ^0.0.8
+      version: 0.0.8
     lucide-react:
       specifier: ^1.16.0
       version: 1.16.0
@@ -169,6 +172,9 @@ importers:
 
   apps/kwadrants:
     dependencies:
+      cnfast:
+        specifier: 'catalog:'
+        version: 0.0.8
       konva:
         specifier: ^10.3.0
         version: 10.3.0
@@ -238,10 +244,13 @@ importers:
         version: 10.3.1(react@19.2.6)
       '@vercel/analytics':
         specifier: 'catalog:'
-        version: 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@vercel/speed-insights':
         specifier: ^2.0.0
         version: 2.0.0(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      cnfast:
+        specifier: 'catalog:'
+        version: 0.0.8
       geist:
         specifier: ^1.7.1
         version: 1.7.1(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
@@ -329,13 +338,16 @@ importers:
         version: 0.17.3
       '@vercel/analytics':
         specifier: 'catalog:'
-        version: 2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       ai:
         specifier: ^6.0.191
         version: 6.0.191(zod@4.4.3)
       better-auth:
         specifier: ^1.6.11
         version: 1.6.11(6048147264569b8dbcd71516a53aa49b)
+      cnfast:
+        specifier: 'catalog:'
+        version: 0.0.8
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
@@ -403,9 +415,9 @@ importers:
       balloons-js:
         specifier: ^0.0.3
         version: 0.0.3
-      clsx:
-        specifier: ^2.1.1
-        version: 2.1.1
+      cnfast:
+        specifier: 'catalog:'
+        version: 0.0.8
       motion:
         specifier: ^12.40.0
         version: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -418,9 +430,6 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.6(react@19.2.6)
-      tailwind-merge:
-        specifier: ^3.6.0
-        version: 3.6.0
       tailwindcss:
         specifier: 'catalog:'
         version: 4.3.0
@@ -476,6 +485,9 @@ importers:
       '@visx/tooltip':
         specifier: ^3.12.0
         version: 3.12.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      cnfast:
+        specifier: 'catalog:'
+        version: 0.0.8
       react:
         specifier: 'catalog:'
         version: 19.2.6
@@ -3524,6 +3536,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cnfast@0.0.8:
+    resolution: {integrity: sha512-EjXKMfGfdwtV4AcNSQ6AwQaVzpC1B7IxeiwA3FlhTXz+YFlMKVi4c1JX9tgD2QOlahQXjB8KUXrBaYG+3v871Q==}
+    hasBin: true
+
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
@@ -5106,9 +5122,6 @@ packages:
 
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
-
-  tailwind-merge@3.6.0:
-    resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
 
   tailwindcss@4.3.0:
     resolution: {integrity: sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==}
@@ -7538,7 +7551,7 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.2.6
 
-  '@vercel/analytics@2.0.1(next@16.2.6(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
+  '@vercel/analytics@2.0.1(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     optionalDependencies:
       next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
@@ -7985,6 +7998,8 @@ snapshots:
   client-only@0.0.1: {}
 
   clsx@2.1.1: {}
+
+  cnfast@0.0.8: {}
 
   commander@7.2.0: {}
 
@@ -9706,8 +9721,6 @@ snapshots:
     optional: true
 
   tabbable@6.4.0: {}
-
-  tailwind-merge@3.6.0: {}
 
   tailwindcss@4.3.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ catalog:
   "@types/react-dom": ^19.2.3
   "@vercel/analytics": ^2.0.1
   "@vitejs/plugin-react": ^6.0.2
+  cnfast: ^0.0.8
   lucide-react: ^1.16.0
   next: ^16.2.6
   postcss: ^8.5.15


### PR DESCRIPTION
## What

Migrate the apps to [`cnfast`](https://github.com/aidenybai/cnfast) — a faster, drop-in replacement for the usual `cn` helper (clsx + tailwind-merge).

## Changes

- **Add `cnfast` to the pnpm catalog** (`^0.0.8`).
- **Export `cn` from `cnfast`** via `src/lib/utils.ts` in the modern Tailwind apps: `kyh`, `kwadrants`, `policingice`, `tc`, `stonksville`.
- **Remove `clsx` and `tailwind-merge`** from `stonksville` — they were the only declared usage of that stack in the repo (and were unused in source).

## Notes

- No app currently imported a `cn` helper or used clsx/tailwind-merge in source, so this wires up the shared `cn` (now backed by cnfast) without changing existing `className` strings. Hand-rolled template-literal classNames can be migrated to `cn(...)` incrementally.
- `covid-19` (legacy JSX/CRA) was left out — it has no clsx/tailwind-merge and a TS `cn` helper doesn't fit there.
- Typecheck passes for all touched apps. The pre-existing `kyh` `tsconfig` `baseUrl` deprecation warning (TS5101) is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LPcDk9hJzBzKY6fs35ECjH

---
_Generated by [Claude Code](https://claude.ai/code/session_01LPcDk9hJzBzKY6fs35ECjH)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and re-export wiring only; no existing `cn` usage or clsx/tailwind-merge call sites were changed in source.
> 
> **Overview**
> Adds **`cnfast`** (`^0.0.8`) to the **pnpm catalog** and declares it in **kyh**, **kwadrants**, **policingice**, **stonksville**, and **tc**.
> 
> Each of those apps now **re-exports `cn` from `cnfast`** through `src/lib/utils.ts` (kwadrants keeps its existing helpers and adds the re-export). **stonksville** drops unused **`clsx`** and **`tailwind-merge`** in favor of cnfast. Lockfile updates follow the new catalog dependency; no app source was switched to call `cn` yet, so runtime className behavior should be unchanged until incremental adoption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec656c6b1c81ea9fb84f3da229eaa1b8e60e3fd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch apps to a shared `cn` helper powered by `cnfast` for faster className merging. Removes legacy `clsx`/`tailwind-merge`; no behavior change.

- **Refactors**
  - Export `cn` from `cnfast` via `src/lib/utils.ts` in kyh, kwadrants, policingice, tc, and stonksville.
  - Keep existing className strings; adopt `cn(...)` incrementally.

- **Dependencies**
  - Add `cnfast` to the workspace catalog and as a dep in the updated apps.
  - Remove `clsx` and `tailwind-merge` from stonksville.

<sup>Written for commit ec656c6b1c81ea9fb84f3da229eaa1b8e60e3fd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/kyh.io/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

