### PR TITLE
chore(skills): sync curated 3p list + CLAUDE.md with local install

### DIFF
--- a/packages/skills/CLAUDE.md
+++ b/packages/skills/CLAUDE.md
@@ -20,6 +20,7 @@
 ## Code Quality Standards
 
 - Make minimal, surgical changes
+- **File naming: kebab-case for all TS/TSX files** (`game-scene.ts`, `use-game-state.ts`), including React components. Exceptions: tool-generated files with mandated names (e.g. `routeTree.gen.ts`)
 - **Never compromise type safety**: No `any`, no non-null assertion operator (`!`), no type assertions (`as Type`)
 - **Make illegal states unrepresentable**: Model domain with ADTs/discriminated unions; parse inputs at boundaries into typed structures; if state can't exist, code can't mishandle it
 - **Abstractions**: Consciously constrained, pragmatically parameterised, doggedly documented

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -67,6 +67,10 @@ into the global space using the bundled `skills` CLI (`skills add <repo> -g -s '
 
 Cherry-pick a single skill manually: `npx skills add <repo>@<skill-name> -g -y`.
 
+### Not installable from a repo
+
+- **`motion`** — the [Motion AI Kit](https://motion.dev/docs/ai-kit). Proprietary (Motion+), not a GitHub/npm skill. Install it manually from motion.dev; `external-skills.json` can't reproduce it.
+
 ## Custom skills
 
 | Skill                       | What it does                                                          |

--- a/packages/skills/external-skills.json
+++ b/packages/skills/external-skills.json
@@ -9,9 +9,11 @@
     "anthropics/skills",
     "mattpocock/skills",
     "jakubkrehel/make-interfaces-feel-better",
-    "vercel-labs/next-skills",
     "remotion-dev/skills",
     "supabase/agent-skills",
-    "vercel-labs/agent-skills"
+    "vercel-labs/agent-skills",
+    "coreyhaines31/marketingskills",
+    "shadcn/improve",
+    "cloudflare/skills"
   ]
 }

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -19,7 +19,8 @@
     "access": "public"
   },
   "scripts": {
-    "postinstall": "node scripts/link.mjs"
+    "postinstall": "node scripts/link.mjs",
+    "check:external": "node scripts/check-external-skills.mjs"
   },
   "engines": {
     "node": ">=18"

--- a/packages/skills/scripts/check-external-skills.mjs
+++ b/packages/skills/scripts/check-external-skills.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// Drift check: every 3p skill installed locally (via the `skills` CLI) should be
+// reproducible by `external-skills.json`. The skills CLI records each install in
+// `~/.agents/.skill-lock.json` with its source repo — compare that against the
+// curated repo list so a fresh `npm i -g @kyh/skills` recreates what we run.
+//
+// The lock lives in the user's home dir, NOT the repo, so this only works on a
+// machine that has the skills installed. CI has no lock -> the check is skipped.
+// Run manually (e.g. before a release): `node scripts/check-external-skills.mjs`.
+//
+// Not every skill comes from a repo (e.g. `motion` = Motion AI Kit from
+// motion.dev). List those here so they don't trip the check.
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const lockPath = join(homedir(), ".agents", ".skill-lock.json");
+const extPath = join(here, "..", "external-skills.json");
+
+// Skills intentionally not sourced from a `skills add <repo>` install.
+const NON_REPO = new Set(["motion"]);
+
+const read = (p) => JSON.parse(readFileSync(p, "utf8"));
+
+let lock;
+try {
+  lock = read(lockPath);
+} catch {
+  console.log(`skip: no lock at ${lockPath} (nothing to check on this machine)`);
+  process.exit(0);
+}
+
+const ext = read(extPath);
+const listed = new Set(ext.repos);
+
+const lockedRepos = new Set();
+const skipped = [];
+for (const [name, meta] of Object.entries(lock.skills ?? {})) {
+  if (NON_REPO.has(name)) {
+    skipped.push(name);
+    continue;
+  }
+  if (meta.source) lockedRepos.add(meta.source);
+}
+
+const missing = [...lockedRepos].filter((r) => !listed.has(r)).sort();
+const dead = [...listed].filter((r) => !lockedRepos.has(r)).sort();
+
+if (skipped.length) console.log(`note: skipped non-repo skills: ${skipped.join(", ")}`);
+
+if (missing.length) {
+  console.error("\nMISSING from external-skills.json (installed locally, not curated):");
+  for (const r of missing) console.error(`  - ${r}`);
+}
+if (dead.length) {
+  console.warn("\nDEAD in external-skills.json (curated, but no installed skill came from it):");
+  for (const r of dead) console.warn(`  - ${r}`);
+}
+
+if (missing.length) {
+  console.error("\nfail: external-skills.json is out of sync. Add the missing repos.");
+  process.exit(1);
+}
+console.log(
+  dead.length
+    ? "\nok with warnings: no missing repos (dead entries above are advisory)."
+    : `\nok: external-skills.json matches all ${lockedRepos.size} locally installed source repos.`,
+);


### PR DESCRIPTION
Aligns the published `@kyh/skills` package with what's actually installed locally, so a fresh `npm i -g @kyh/skills` reproduces my real setup.

## Changes
- **`external-skills.json`**: +`coreyhaines31/marketingskills` (copywriting), +`shadcn/improve`, +`cloudflare/skills`; dropped stale `vercel-labs/next-skills` (contributed nothing — those Vercel skills come from `agent-skills`). Now maps 1:1 to every 3p skill in `~/.agents/.skill-lock.json`.
- **`CLAUDE.md`**: backported the kebab-case file-naming rule (had drifted vs global `~/.claude/CLAUDE.md`).
- **`scripts/check-external-skills.mjs`** (+ `pnpm check:external`): drift check comparing the local skills-CLI lock against the curated repo list. Lock is machine-local, so it's a manual/pre-release check, not CI.
- **`README.md`**: documented `motion` as a manual install (Motion AI Kit from motion.dev — proprietary, not a repo).

## Notes
- The 7 custom skills were already byte-identical to global — no changes needed.
- `motion` can't be curated (not a GitHub/npm skill); documented as manual.
- `cloudflare/skills` trips an advisory "DEAD" warning on my current machine only (those skills predate the lock); self-heals on next reinstall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and package curation only; postinstall behavior changes which external repos are fetched, with no auth or app runtime impact.
> 
> **Overview**
> Aligns **`external-skills.json`** with locally installed third-party skills so a fresh global `@kyh/skills` install pulls the same repos: adds **`coreyhaines31/marketingskills`**, **`shadcn/improve`**, and **`cloudflare/skills`**, and drops **`vercel-labs/next-skills`** as redundant with **`vercel-labs/agent-skills`**.
> 
> Adds **`scripts/check-external-skills.mjs`** and **`check:external`** to compare `~/.agents/.skill-lock.json` against the curated list (fails on missing repos, advisory “dead” entries; skips when no lock, e.g. CI). Documents **`motion`** as a manual Motion AI Kit install in **README**. Backports the **kebab-case TS/TSX file naming** rule into package **`CLAUDE.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22a7c884164f7d292004c45a6100538a7512672d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the curated third‑party skills list with the actual local install so a fresh `npm i -g @kyh/skills` reproduces the setup. Adds a manual drift check and updates docs (kebab‑case rule; `motion` is manual).

- **New Features**
  - `external-skills.json`: +`coreyhaines31/marketingskills`, +`shadcn/improve`, +`cloudflare/skills`; removed `vercel-labs/next-skills`.
  - Added `scripts/check-external-skills.mjs` and `pnpm check:external` to compare `~/.agents/.skill-lock.json` with the curated list; skips if no lock; ignores non‑repo `motion`.
  - `CLAUDE.md`: enforce kebab‑case for TS/TSX filenames.
  - `README.md`: documented `motion` (Motion AI Kit) as a manual install, not reproducible from a repo.

<sup>Written for commit 22a7c884164f7d292004c45a6100538a7512672d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kyh/kyh.io/pull/31?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

